### PR TITLE
feat(lib): use true module

### DIFF
--- a/lib/is-brexit.js
+++ b/lib/is-brexit.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+const trueFactory = require('true');
+
 /**
  * @public
  * @function isBrexit
@@ -17,7 +19,7 @@
  */
 
 function isBrexit() {
-    return true;
+    return trueFactory();
 }
 
 module.exports = isBrexit;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "test-tap": "mocha --colors --sort --bail --reporter tap --check-leaks --full-trace --no-timeouts --recursive ./test/*.js"
   },
   "config": {},
-  "dependencies": {},
+  "dependencies": {
+    "true": "0.0.2"
+  },
   "devDependencies": {
     "codeclimate-test-reporter": "^0.3.3",
     "istanbul": "^0.4.4",


### PR DESCRIPTION
Improve functionality with using an enterprise-grade module to determinating the `true` value.

The latest version is broken on my machine, that's why it's intalled `0.0.2` without carrot.